### PR TITLE
Replace Singleton with ApplicationScoped in example

### DIFF
--- a/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/RetrievalAugmentorExample.java
+++ b/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/RetrievalAugmentorExample.java
@@ -2,7 +2,7 @@ package io.quarkiverse.langchain4j.samples;
 
 import java.util.function.Supplier;
 
-import jakarta.inject.Singleton;
+import jakarta.inject.ApplicationScoped;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
@@ -10,7 +10,7 @@ import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import io.quarkiverse.langchain4j.redis.RedisEmbeddingStore;
 
-@Singleton
+@ApplicationScoped
 public class RetrievalAugmentorExample implements Supplier<RetrievalAugmentor> {
 
     private final RetrievalAugmentor augmentor;


### PR DESCRIPTION
It was a bit strange to see `Singleton` here vs `@ApplicationScoped` for the rest of the code in the documentation.
I'm not an expert and there is possibly a good reason but if not, better be consistent in the examples to avoid minds like me to wonder why.